### PR TITLE
Fix low pulse width labels

### DIFF
--- a/source/Variable RGB LED Solution/Variable RGB LED/MainPage.xaml
+++ b/source/Variable RGB LED Solution/Variable RGB LED/MainPage.xaml
@@ -114,7 +114,7 @@
 								   VerticalAlignment="Center" />
 
 						<!-- Low Pulse Label -->
-						<TextBlock Text="{x:Bind RedLowPulseWidth, Converter={StaticResource ValueFormatConverter}, ConverterParameter='High = [0:#,##0.0] μs', Mode=OneWay}"
+                        <TextBlock Text="{x:Bind RedLowPulseWidth, Converter={StaticResource ValueFormatConverter}, ConverterParameter='Low = [0:#,##0.0] μs', Mode=OneWay}"
 								   Style="{ThemeResource BodyTextBlockStyle}"
 								   HorizontalAlignment="Right"
 								   VerticalAlignment="Center" />
@@ -249,7 +249,7 @@
 								   VerticalAlignment="Center" />
 
 						<!-- Low Pulse Label -->
-						<TextBlock Text="{x:Bind GreenLowPulseWidth, Converter={StaticResource ValueFormatConverter}, ConverterParameter='High = [0:#,##0.0] μs', Mode=OneWay}"
+						<TextBlock Text="{x:Bind GreenLowPulseWidth, Converter={StaticResource ValueFormatConverter}, ConverterParameter='Low = [0:#,##0.0] μs', Mode=OneWay}"
 								   Style="{ThemeResource BodyTextBlockStyle}"
 								   HorizontalAlignment="Right"
 								   VerticalAlignment="Center" />
@@ -384,7 +384,7 @@
 								   VerticalAlignment="Center" />
 
 						<!-- Low Pulse Label -->
-						<TextBlock Text="{x:Bind BlueLowPulseWidth, Converter={StaticResource ValueFormatConverter}, ConverterParameter='High = [0:#,##0.0] μs', Mode=OneWay}"
+                        <TextBlock Text="{x:Bind BlueLowPulseWidth, Converter={StaticResource ValueFormatConverter}, ConverterParameter='Low = [0:#,##0.0] μs', Mode=OneWay}"
 								   Style="{ThemeResource BodyTextBlockStyle}"
 								   HorizontalAlignment="Right"
 								   VerticalAlignment="Center" />


### PR DESCRIPTION
Low pulse width labels previously had "High" written on them (as did the high pulse width labels). This fork fixes this.
