### PR TITLE
Remove missing signing key from project file

### DIFF
--- a/source/Variable RGB LED Solution/Variable RGB LED/Variable RGB LED.csproj
+++ b/source/Variable RGB LED Solution/Variable RGB LED/Variable RGB LED.csproj
@@ -112,7 +112,6 @@
       <SubType>Designer</SubType>
     </AppxManifest>
     <None Include="project.json" />
-    <None Include="Variable RGB LED_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\background.png" />


### PR DESCRIPTION
The project file included a temporary key to sign the project. Since it wasn't used anyway this change removes that key from the project file to avoid a warning in the solution explorer.
