### PR TITLE
Removed another (harder to find) reference to the key file

### DIFF
--- a/source/Variable RGB LED Solution/Variable RGB LED/Variable RGB LED.csproj
+++ b/source/Variable RGB LED Solution/Variable RGB LED/Variable RGB LED.csproj
@@ -17,7 +17,6 @@
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <PackageCertificateKeyFile>Variable RGB LED_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Sorry, last commit didn't catch all references to the key and resulted in a warning during compilation.
